### PR TITLE
Add support for Diners Club (BRA)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ rvm:
   - 2.1.2
 
 script: 'bundle exec rake'
+
+before_install:
+  - gem update bundler

--- a/lib/credit_card_bins/bin.rb
+++ b/lib/credit_card_bins/bin.rb
@@ -1,7 +1,7 @@
 module CreditCardBins; end
 
 class CreditCardBins::Bin
-  
+
   AttrReaders = [
     :bin,
     :brand,
@@ -97,6 +97,10 @@ class CreditCardBins::Bin
 
   def solo?
     @data["brand"] == "SOLO"
+  end
+
+  def diners_club?
+    @data["brand"] == "DINERS CLUB"
   end
 
   ### Type

--- a/lib/data/3/3607.yml
+++ b/lib/data/3/3607.yml
@@ -69,3 +69,13 @@
     alpha_2: US
     alpha_3: USA
     name: United States
+'360756':
+  bin: '360756'
+  brand: DINERS CLUB
+  type: CREDIT
+  category: ''
+  issuer: CITIBANK
+  country:
+    alpha_2: BR
+    alpha_3: BRA
+    name: Brazil

--- a/spec/credit_card_bins_spec.rb
+++ b/spec/credit_card_bins_spec.rb
@@ -132,7 +132,7 @@ describe CreditCardBins do
   end
 
   describe "methods" do
-    
+
     it "include a private_label? query" do
       valid_private_label_bin = CreditCardBin.new("019627")
       expect(valid_private_label_bin.private_label?).to eq(true)
@@ -215,6 +215,13 @@ describe CreditCardBins do
       expect(valid_solo_bin.solo?).to eq(true)
       invalid_solo_bin = CreditCardBin.new("497040")
       expect(invalid_solo_bin.solo?).to eq(false)
+    end
+
+    it "include a diners club? query" do
+      valid_diners_club_bin = CreditCardBin.new("360756")
+      expect(valid_diners_club_bin.diners_club?).to eq(true)
+      valid_diners_club_bin = CreditCardBin.new("497040")
+      expect(valid_diners_club_bin.diners_club?).to eq(false)
     end
 
 


### PR DESCRIPTION
I just added support for the Diners Club brand for Brazilians customers. New method: **diners_club?** also available from now on.
